### PR TITLE
289 fix ranking api not working

### DIFF
--- a/server/src/entities/submission.entity.ts
+++ b/server/src/entities/submission.entity.ts
@@ -1,4 +1,3 @@
-import { Status } from '../const/boj-results';
 import {
   BaseEntity,
   Column,
@@ -6,6 +5,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { Status } from '../const/boj-results';
 import Problem from './problem.entity';
 import Room from './room.entity';
 import User from './user.entity';
@@ -37,4 +37,7 @@ export default class Submission extends BaseEntity {
 
   @ManyToOne(() => Problem, (problem) => problem.submissions, { cascade: true })
   problem?: Problem;
+
+  @Column()
+  alreadyAccepted!: boolean;
 }

--- a/server/src/room/room-code/room-code.pipe.spec.ts
+++ b/server/src/room/room-code/room-code.pipe.spec.ts
@@ -1,0 +1,7 @@
+import { RoomCodePipe } from './room-code.pipe';
+
+describe('RoomCodePipe', () => {
+  it('should be defined', () => {
+    expect(new RoomCodePipe()).toBeDefined();
+  });
+});

--- a/server/src/room/room-code/room-code.pipe.ts
+++ b/server/src/room/room-code/room-code.pipe.ts
@@ -1,0 +1,19 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+
+@Injectable()
+export class RoomCodePipe implements PipeTransform {
+  transform(value: any, _metadata: ArgumentMetadata) {
+    const hexRegExp = /^[0-9a-fA-F]{6}$/;
+
+    if (!hexRegExp.test(value)) {
+      throw new BadRequestException('Invalid room code');
+    }
+
+    return value;
+  }
+}

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -15,6 +15,7 @@ import { Request } from 'express';
 import { SessionAuthGuard } from '../auth/auth.guard';
 import User from '../entities/user.entity';
 import { RoomUserService } from '../room-user/room-user.service';
+import { RoomCodePipe } from './room-code/room-code.pipe';
 import { RoomService } from './room.service';
 
 @Controller('room')
@@ -68,5 +69,11 @@ export class RoomController {
   @HttpCode(HttpStatus.OK)
   async getRoomUsers(@Param('code') code: string) {
     return await this.roomUserService.findUsersByRoomCode(code);
+  }
+
+  @Get('/:code/rankings')
+  @HttpCode(HttpStatus.OK)
+  async getRoomRankings(@Param('code', RoomCodePipe) code: string) {
+    return await this.roomService.getRoomRankings(code);
   }
 }

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -148,15 +148,14 @@ export class RoomService {
       .innerJoin(
         'room.submissions',
         'submission',
-        'submission.status = :status AND submission.user_id = user.id',
+        'submission.status = :status AND submission.user_id = user.id AND submission.alreadyAccepted = false',
         {
           status: Status.ACCEPTED,
         },
       )
-      .innerJoin('submission.problem', 'problem')
       .select('user.id', 'userId')
       .addSelect('user.username', 'username')
-      .addSelect('COUNT(DISTINCT submission.problem)', 'acceptedCount')
+      .addSelect('COUNT(submission.id)', 'acceptedCount')
       .addSelect('MAX(submission.submittedAt)', 'lastAcceptedAt')
       .groupBy('user.id')
       .orderBy('acceptedCount', 'DESC')

--- a/server/src/submission/submission.service.ts
+++ b/server/src/submission/submission.service.ts
@@ -105,6 +105,15 @@ export class SubmissionService {
       status,
     );
 
+    const alreadyAccepted = await this.submissionRepository.exist({
+      where: {
+        user: { id: user.id },
+        problem: { id: problem.id },
+        room: { id: room.id },
+        status: Status.ACCEPTED,
+      },
+    });
+
     return await this.submissionRepository
       .create({
         status,
@@ -112,6 +121,7 @@ export class SubmissionService {
         room,
         problem,
         submittedAt,
+        alreadyAccepted,
       })
       .save();
   }


### PR DESCRIPTION


## Checklist

- [ ] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?

간단한 유닛 테스트만 하고 통합 테스트 X. 프론트와 함께 할 예정. @glowisn 

## Description

```ts
 /**
   * returns an array of user id, username, and the number of accepted problems of the user, sorted by the number of accepted problems
   * @param code
   */
  async getRoomRankings(code: string) {
    Submission;
    User;
    const qb = this.roomRepository
      .createQueryBuilder('room')
      .where('room.code = :code', { code })
      .innerJoin('room.joinedUsers', 'roomUser')
      .innerJoin('roomUser.user', 'user')
      .innerJoin(
        'room.submissions',
        'submission',
        'submission.status = :status AND submission.user_id = user.id AND submission.alreadyAccepted = false',
        {
          status: Status.ACCEPTED,
        },
      )
      .select('user.id', 'userId')
      .addSelect('user.username', 'username')
      .addSelect('COUNT(submission.id)', 'acceptedCount')
      .addSelect('MAX(submission.submittedAt)', 'lastAcceptedAt')
      .groupBy('user.id')
      .orderBy('acceptedCount', 'DESC')
      .addOrderBy('lastAcceptedAt', 'ASC');

    const data = await qb.getRawMany();
    return { data };
  }
  ```

1. 유저의 이름을 추출하기 위해 roomuser, user 테이블 조인
2. 해당 룸에 제출된 'submission' 중, 최초 AC를 받은 제출들만 조인
3. 가장 많은 문제를 맞춘 사람 -> 같으면 가장 빨리 마지막 문제를 AC를 받은 사람으로 정렬

## Changes Made

현재 제출에 대하여

1. 특정 유저가 
3. 특정 방에서 
3. 특정 문제에 대해 
4. '최초'로 AC를 받은 문제인지 

여부를 판별하는 alreadyAccepted: boolean 칼럼을 submission entity에 추가하였습니다.
